### PR TITLE
Add prefix and middleware parameter to Evo::routes

### DIFF
--- a/src/Evo.php
+++ b/src/Evo.php
@@ -52,11 +52,14 @@ class Evo
      * @param  string $controller
      * @return void
      */
-    public function routes(string $controller)
-    {
+    public function routes(
+        string $controller,
+        string $prefix = '',
+        string|array|null $middleware = null,
+    ) {
         $this->controllers[] = $controller;
 
-        $routes = $this->getRoutesFromController($controller);
+        $routes = $this->getRoutesFromController($controller, $prefix, $middleware);
         $hasGroupStack = $this->router->hasGroupStack();
         $lastGroupPrefix = $this->router->getLastGroupPrefix();
 
@@ -91,7 +94,11 @@ class Evo
      * @param  string $controller
      * @return Route[]
      */
-    protected function getRoutesFromController(string $controller): array
+    protected function getRoutesFromController(
+        string $controller,
+        string $prefix = '',
+        array|string|null $middleware = null,
+    ): array
     {
         $routes = [];
         $reflection = new ReflectionClass($controller);
@@ -112,9 +119,18 @@ class Evo
              * @var \Emsifa\Evo\Route\Route $route
              */
             foreach ($methodRoutes as $route) {
+                if ($middleware) {
+                    $route->middleware($middleware);
+                }
+
                 $route->setUses($controller.'@'.$method->getName());
                 $route->setContainer($this->container);
                 $routes[] = $this->applyRouteModifiers($route, $routeModifiers);
+
+                if ($prefix) {
+                    $uri = rtrim($prefix, "/") . "/" . ltrim($route->uri(), "/");
+                    $route->setUri($uri);
+                }
             }
         }
 

--- a/src/Evo.php
+++ b/src/Evo.php
@@ -98,8 +98,7 @@ class Evo
         string $controller,
         string $prefix = '',
         array|string|null $middleware = null,
-    ): array
-    {
+    ): array {
         $routes = [];
         $reflection = new ReflectionClass($controller);
         $classRouteModifiers = ReflectionHelper::getAttributesInstances($reflection, RouteModifier::class, ReflectionAttribute::IS_INSTANCEOF);

--- a/tests/EvoTest.php
+++ b/tests/EvoTest.php
@@ -14,112 +14,112 @@ use ReflectionMethod;
 
 class EvoTest extends TestCase
 {
-    // public function testGetRoutesFromController()
-    // {
-    //     $container = new Container;
-    //     $evo = new Evo(new Router(new Dispatcher($container)), $container);
-    //     $getRoutesFromController = new ReflectionMethod($evo, 'getRoutesFromController');
-    //     $getRoutesFromController->setAccessible(true);
+    public function testGetRoutesFromController()
+    {
+        $container = new Container;
+        $evo = new Evo(new Router(new Dispatcher($container)), $container);
+        $getRoutesFromController = new ReflectionMethod($evo, 'getRoutesFromController');
+        $getRoutesFromController->setAccessible(true);
 
-    //     /**
-    //      * @var Route[]
-    //      */
-    //     $routes = $getRoutesFromController->invokeArgs($evo, [SampleController::class]);
+        /**
+         * @var Route[]
+         */
+        $routes = $getRoutesFromController->invokeArgs($evo, [SampleController::class]);
 
-    //     $this->assertEquals(6, count($routes));
+        $this->assertEquals(6, count($routes));
 
-    //     $this->assertEquals('sample', $routes[0]->uri);
-    //     $this->assertEquals(['GET', 'HEAD'], $routes[0]->methods());
+        $this->assertEquals('sample', $routes[0]->uri);
+        $this->assertEquals(['GET', 'HEAD'], $routes[0]->methods());
 
-    //     $this->assertEquals('sample/stuff', $routes[1]->uri);
-    //     $this->assertEquals(['GET', 'HEAD'], $routes[1]->methods());
+        $this->assertEquals('sample/stuff', $routes[1]->uri);
+        $this->assertEquals(['GET', 'HEAD'], $routes[1]->methods());
 
-    //     $this->assertEquals('sample/stuff', $routes[2]->uri);
-    //     $this->assertEquals(['POST'], $routes[2]->methods());
+        $this->assertEquals('sample/stuff', $routes[2]->uri);
+        $this->assertEquals(['POST'], $routes[2]->methods());
 
-    //     $this->assertEquals('sample/stuff', $routes[3]->uri);
-    //     $this->assertEquals(['PUT'], $routes[3]->methods());
+        $this->assertEquals('sample/stuff', $routes[3]->uri);
+        $this->assertEquals(['PUT'], $routes[3]->methods());
 
-    //     $this->assertEquals('sample/stuff', $routes[4]->uri);
-    //     $this->assertEquals(['PATCH'], $routes[4]->methods());
+        $this->assertEquals('sample/stuff', $routes[4]->uri);
+        $this->assertEquals(['PATCH'], $routes[4]->methods());
 
-    //     $this->assertEquals('sample/stuff', $routes[5]->uri);
-    //     $this->assertEquals(['DELETE'], $routes[5]->methods());
-    // }
+        $this->assertEquals('sample/stuff', $routes[5]->uri);
+        $this->assertEquals(['DELETE'], $routes[5]->methods());
+    }
 
-    // public function testGetControllers()
-    // {
-    //     $evo = new Evo($this->app->make(Router::class), $this->app);
+    public function testGetControllers()
+    {
+        $evo = new Evo($this->app->make(Router::class), $this->app);
 
-    //     $evo->routes(SampleController::class);
-    //     $evo->routes(SampleSwaggerController::class);
+        $evo->routes(SampleController::class);
+        $evo->routes(SampleSwaggerController::class);
 
-    //     $controllers = $evo->getControllers();
+        $controllers = $evo->getControllers();
 
-    //     $this->assertEquals([SampleController::class, SampleSwaggerController::class], $controllers);
-    // }
+        $this->assertEquals([SampleController::class, SampleSwaggerController::class], $controllers);
+    }
 
-    // public function testGetContainer()
-    // {
-    //     $evo = new Evo($this->app->make(Router::class), $this->app);
+    public function testGetContainer()
+    {
+        $evo = new Evo($this->app->make(Router::class), $this->app);
 
-    //     $this->assertEquals($this->app, $evo->getContainer());
-    // }
+        $this->assertEquals($this->app, $evo->getContainer());
+    }
 
-    // public function testGetRouter()
-    // {
-    //     $router = $this->app->make(Router::class);
-    //     $evo = new Evo($router, $this->app);
+    public function testGetRouter()
+    {
+        $router = $this->app->make(Router::class);
+        $evo = new Evo($router, $this->app);
 
-    //     $this->assertEquals($router, $evo->getRouter());
-    // }
+        $this->assertEquals($router, $evo->getRouter());
+    }
 
-    // public function testSwagger()
-    // {
-    //     /**
-    //      * @var Router
-    //      */
-    //     $router = $this->app->make(Router::class);
-    //     $evo = new Evo($router, $this->app);
+    public function testSwagger()
+    {
+        /**
+         * @var Router
+         */
+        $router = $this->app->make(Router::class);
+        $evo = new Evo($router, $this->app);
 
-    //     $this->assertNull($router->getRoutes()->getByAction(SwaggerController::class.'@showUi'));
-    //     $this->assertNull($router->getRoutes()->getByAction(SwaggerController::class.'@openApi'));
+        $this->assertNull($router->getRoutes()->getByAction(SwaggerController::class.'@showUi'));
+        $this->assertNull($router->getRoutes()->getByAction(SwaggerController::class.'@openApi'));
 
-    //     $evo->swagger('/api/docs', middleware: 'auth');
+        $evo->swagger('/api/docs', middleware: 'auth');
 
-    //     $this->assertNotNull($router->getRoutes()->getByAction(SwaggerController::class.'@showUi'));
-    //     $this->assertNotNull($router->getRoutes()->getByAction(SwaggerController::class.'@openApi'));
-    // }
+        $this->assertNotNull($router->getRoutes()->getByAction(SwaggerController::class.'@showUi'));
+        $this->assertNotNull($router->getRoutes()->getByAction(SwaggerController::class.'@openApi'));
+    }
 
-    // public function testRegisterRoutesInAGroup()
-    // {
-    //     /**
-    //      * @var Router
-    //      */
-    //     $router = $this->app->make(Router::class);
-    //     $evo = new Evo($router, $this->app);
+    public function testRegisterRoutesInAGroup()
+    {
+        /**
+         * @var Router
+         */
+        $router = $this->app->make(Router::class);
+        $evo = new Evo($router, $this->app);
 
-    //     $router->group([
-    //         'prefix' => '/foo',
-    //         'middleware' => 'auth',
-    //     ], function () use ($evo) {
-    //         $evo->routes(SampleController::class);
-    //     });
+        $router->group([
+            'prefix' => '/foo',
+            'middleware' => 'auth',
+        ], function () use ($evo) {
+            $evo->routes(SampleController::class);
+        });
 
-    //     $routes = $router->getRoutes()->getRoutes();
+        $routes = $router->getRoutes()->getRoutes();
 
-    //     $this->assertEquals("/foo/sample", $routes[0]->uri());
-    //     $this->assertEquals(["GET", "HEAD"], $routes[0]->methods());
-    //     $this->assertEquals(["auth"], $routes[0]->middleware());
+        $this->assertEquals("/foo/sample", $routes[0]->uri());
+        $this->assertEquals(["GET", "HEAD"], $routes[0]->methods());
+        $this->assertEquals(["auth"], $routes[0]->middleware());
 
-    //     $this->assertEquals("/foo/sample/stuff", $routes[1]->uri());
-    //     $this->assertEquals(["GET", "HEAD"], $routes[1]->methods());
-    //     $this->assertEquals(["auth"], $routes[1]->middleware());
+        $this->assertEquals("/foo/sample/stuff", $routes[1]->uri());
+        $this->assertEquals(["GET", "HEAD"], $routes[1]->methods());
+        $this->assertEquals(["auth"], $routes[1]->middleware());
 
-    //     $this->assertEquals("/foo/sample/stuff", $routes[2]->uri());
-    //     $this->assertEquals(["POST"], $routes[2]->methods());
-    //     $this->assertEquals(["auth"], $routes[2]->middleware());
-    // }
+        $this->assertEquals("/foo/sample/stuff", $routes[2]->uri());
+        $this->assertEquals(["POST"], $routes[2]->methods());
+        $this->assertEquals(["auth"], $routes[2]->middleware());
+    }
 
     public function testRegisterRoutesWithPrefixAndMiddleware()
     {

--- a/tests/EvoTest.php
+++ b/tests/EvoTest.php
@@ -14,100 +14,121 @@ use ReflectionMethod;
 
 class EvoTest extends TestCase
 {
-    /**
-     * @test
-     */
-    public function testGetRoutesFromController()
-    {
-        $container = new Container;
-        $evo = new Evo(new Router(new Dispatcher($container)), $container);
-        $getRoutesFromController = new ReflectionMethod($evo, 'getRoutesFromController');
-        $getRoutesFromController->setAccessible(true);
+    // public function testGetRoutesFromController()
+    // {
+    //     $container = new Container;
+    //     $evo = new Evo(new Router(new Dispatcher($container)), $container);
+    //     $getRoutesFromController = new ReflectionMethod($evo, 'getRoutesFromController');
+    //     $getRoutesFromController->setAccessible(true);
 
-        /**
-         * @var Route[]
-         */
-        $routes = $getRoutesFromController->invokeArgs($evo, [SampleController::class]);
+    //     /**
+    //      * @var Route[]
+    //      */
+    //     $routes = $getRoutesFromController->invokeArgs($evo, [SampleController::class]);
 
-        $this->assertEquals(6, count($routes));
+    //     $this->assertEquals(6, count($routes));
 
-        $this->assertEquals('sample', $routes[0]->uri);
-        $this->assertEquals(['GET', 'HEAD'], $routes[0]->methods());
+    //     $this->assertEquals('sample', $routes[0]->uri);
+    //     $this->assertEquals(['GET', 'HEAD'], $routes[0]->methods());
 
-        $this->assertEquals('sample/stuff', $routes[1]->uri);
-        $this->assertEquals(['GET', 'HEAD'], $routes[1]->methods());
+    //     $this->assertEquals('sample/stuff', $routes[1]->uri);
+    //     $this->assertEquals(['GET', 'HEAD'], $routes[1]->methods());
 
-        $this->assertEquals('sample/stuff', $routes[2]->uri);
-        $this->assertEquals(['POST'], $routes[2]->methods());
+    //     $this->assertEquals('sample/stuff', $routes[2]->uri);
+    //     $this->assertEquals(['POST'], $routes[2]->methods());
 
-        $this->assertEquals('sample/stuff', $routes[3]->uri);
-        $this->assertEquals(['PUT'], $routes[3]->methods());
+    //     $this->assertEquals('sample/stuff', $routes[3]->uri);
+    //     $this->assertEquals(['PUT'], $routes[3]->methods());
 
-        $this->assertEquals('sample/stuff', $routes[4]->uri);
-        $this->assertEquals(['PATCH'], $routes[4]->methods());
+    //     $this->assertEquals('sample/stuff', $routes[4]->uri);
+    //     $this->assertEquals(['PATCH'], $routes[4]->methods());
 
-        $this->assertEquals('sample/stuff', $routes[5]->uri);
-        $this->assertEquals(['DELETE'], $routes[5]->methods());
-    }
+    //     $this->assertEquals('sample/stuff', $routes[5]->uri);
+    //     $this->assertEquals(['DELETE'], $routes[5]->methods());
+    // }
 
-    public function testGetControllers()
-    {
-        $evo = new Evo($this->app->make(Router::class), $this->app);
+    // public function testGetControllers()
+    // {
+    //     $evo = new Evo($this->app->make(Router::class), $this->app);
 
-        $evo->routes(SampleController::class);
-        $evo->routes(SampleSwaggerController::class);
+    //     $evo->routes(SampleController::class);
+    //     $evo->routes(SampleSwaggerController::class);
 
-        $controllers = $evo->getControllers();
+    //     $controllers = $evo->getControllers();
 
-        $this->assertEquals([SampleController::class, SampleSwaggerController::class], $controllers);
-    }
+    //     $this->assertEquals([SampleController::class, SampleSwaggerController::class], $controllers);
+    // }
 
-    public function testGetContainer()
-    {
-        $evo = new Evo($this->app->make(Router::class), $this->app);
+    // public function testGetContainer()
+    // {
+    //     $evo = new Evo($this->app->make(Router::class), $this->app);
 
-        $this->assertEquals($this->app, $evo->getContainer());
-    }
+    //     $this->assertEquals($this->app, $evo->getContainer());
+    // }
 
-    public function testGetRouter()
-    {
-        $router = $this->app->make(Router::class);
-        $evo = new Evo($router, $this->app);
+    // public function testGetRouter()
+    // {
+    //     $router = $this->app->make(Router::class);
+    //     $evo = new Evo($router, $this->app);
 
-        $this->assertEquals($router, $evo->getRouter());
-    }
+    //     $this->assertEquals($router, $evo->getRouter());
+    // }
 
-    public function testSwagger()
+    // public function testSwagger()
+    // {
+    //     /**
+    //      * @var Router
+    //      */
+    //     $router = $this->app->make(Router::class);
+    //     $evo = new Evo($router, $this->app);
+
+    //     $this->assertNull($router->getRoutes()->getByAction(SwaggerController::class.'@showUi'));
+    //     $this->assertNull($router->getRoutes()->getByAction(SwaggerController::class.'@openApi'));
+
+    //     $evo->swagger('/api/docs', middleware: 'auth');
+
+    //     $this->assertNotNull($router->getRoutes()->getByAction(SwaggerController::class.'@showUi'));
+    //     $this->assertNotNull($router->getRoutes()->getByAction(SwaggerController::class.'@openApi'));
+    // }
+
+    // public function testRegisterRoutesInAGroup()
+    // {
+    //     /**
+    //      * @var Router
+    //      */
+    //     $router = $this->app->make(Router::class);
+    //     $evo = new Evo($router, $this->app);
+
+    //     $router->group([
+    //         'prefix' => '/foo',
+    //         'middleware' => 'auth',
+    //     ], function () use ($evo) {
+    //         $evo->routes(SampleController::class);
+    //     });
+
+    //     $routes = $router->getRoutes()->getRoutes();
+
+    //     $this->assertEquals("/foo/sample", $routes[0]->uri());
+    //     $this->assertEquals(["GET", "HEAD"], $routes[0]->methods());
+    //     $this->assertEquals(["auth"], $routes[0]->middleware());
+
+    //     $this->assertEquals("/foo/sample/stuff", $routes[1]->uri());
+    //     $this->assertEquals(["GET", "HEAD"], $routes[1]->methods());
+    //     $this->assertEquals(["auth"], $routes[1]->middleware());
+
+    //     $this->assertEquals("/foo/sample/stuff", $routes[2]->uri());
+    //     $this->assertEquals(["POST"], $routes[2]->methods());
+    //     $this->assertEquals(["auth"], $routes[2]->middleware());
+    // }
+
+    public function testRegisterRoutesWithPrefixAndMiddleware()
     {
         /**
          * @var Router
          */
         $router = $this->app->make(Router::class);
         $evo = new Evo($router, $this->app);
-
-        $this->assertNull($router->getRoutes()->getByAction(SwaggerController::class.'@showUi'));
-        $this->assertNull($router->getRoutes()->getByAction(SwaggerController::class.'@openApi'));
-
-        $evo->swagger('/api/docs', middleware: 'auth');
-
-        $this->assertNotNull($router->getRoutes()->getByAction(SwaggerController::class.'@showUi'));
-        $this->assertNotNull($router->getRoutes()->getByAction(SwaggerController::class.'@openApi'));
-    }
-
-    public function testRegisterRoutesInAGroup()
-    {
-        /**
-         * @var Router
-         */
-        $router = $this->app->make(Router::class);
-        $evo = new Evo($router, $this->app);
-
-        $router->group([
-            'prefix' => '/foo',
-            'middleware' => 'auth',
-        ], function () use ($evo) {
-            $evo->routes(SampleController::class);
-        });
+        $evo->routes(SampleController::class, prefix: '/foo', middleware: 'auth');
 
         $routes = $router->getRoutes()->getRoutes();
 


### PR DESCRIPTION
This PR add optional parameters `string $prefix` and `string|array|null $middleware` to `Evo::routes` method. So we can register routes using same controller with different path and middleware.