### PR TITLE
Fix ControllerDispatcher on cached routes

### DIFF
--- a/src/EvoServiceProvider.php
+++ b/src/EvoServiceProvider.php
@@ -5,6 +5,8 @@ namespace Emsifa\Evo;
 use Emsifa\Evo\Commands\MakeDtoCommand;
 use Emsifa\Evo\Commands\MakeResponseCommand;
 use Illuminate\Container\Container;
+use Illuminate\Contracts\Foundation\CachesRoutes;
+use Illuminate\Routing\Contracts\ControllerDispatcher as ControllerDispatcherContract;
 use Illuminate\Routing\Router;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
@@ -32,6 +34,14 @@ class EvoServiceProvider extends PackageServiceProvider
         $this->app->singleton(Evo::class, function () {
             return new Evo(app(Router::class), app(Container::class));
         });
+
+        // @codeCoverageIgnoreStart
+        if ($this->app instanceof CachesRoutes && $this->app->routesAreCached()) {
+            $this->app->bind(ControllerDispatcherContract::class, function () {
+                return new ControllerDispatcher($this->app);
+            });
+        }
+        // @codeCoverageIgnoreEnd
 
         $this->app->bind('evo', fn () => $this->app->make(Evo::class));
     }


### PR DESCRIPTION
In this PR we modify `EvoServiceProvider::registeringPackage` method, check if routes are cached, we bind `Illuminate\Routing\Contracts\ControllerDispatcher` to `Emsifa\Evo\ControllerDispatcher`.

The drawbacks with this approach is some features on Laravel built-in ControllerDispatcher, such as model binding may not work. So later we have to note this in the documentation.

Close #180 