### PR TITLE
Fix OpenAPI generator error when route action doesnt use @ syntax

### DIFF
--- a/src/Swagger/OpenApi/Generator.php
+++ b/src/Swagger/OpenApi/Generator.php
@@ -142,7 +142,14 @@ class Generator
             return false;
         }
 
-        [$className, $methodName] = explode("@", $controller);
+        $explode = explode("@", $controller);
+        // @codeCoverageIgnoreStart
+        if (count($explode) < 2) {
+            return false;
+        }
+        // @codeCoverageIgnoreEnd
+
+        [$className, $methodName] = $explode;
         $method = new ReflectionMethod($className, $methodName);
         $returnType = $method->getReturnType();
 


### PR DESCRIPTION
This PR resolves error generating OpenAPI when application has route that doesn't use "ControllerName@method" syntax.